### PR TITLE
Add ESLint rules for curly braces and semicolons

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -22,6 +22,8 @@ export default [
       '@typescript-eslint/no-unused-vars': ['error', { argsIgnorePattern: '^_' }],
       '@typescript-eslint/explicit-function-return-type': 'off',
       '@typescript-eslint/no-explicit-any': 'warn',
+      curly: 'error',
+      semi: 'error',
     },
   },
   {
@@ -32,6 +34,8 @@ export default [
     },
     rules: {
       'no-unused-vars': ['error', { argsIgnorePattern: '^_', varsIgnorePattern: '^_' }],
+      curly: 'error',
+      semi: 'error',
     },
   },
   {


### PR DESCRIPTION
## Summary
- Adds `curly: 'error'` to require braces around all block statements
- Adds `semi: 'error'` to require semicolons at end of statements

These rules enforce consistent code style so that:
- `if (foo) bar` will fail linting (must be `if (foo) { bar; }`)
- Missing semicolons will fail linting

Fixes #41

🤖 Generated with [Claude Code](https://claude.com/claude-code)