### PR TITLE
CI: Only run native build on C++ changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -4,34 +4,20 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'native/**'
-      - 'dsp/**'
-      - 'src/**'
-      - 'public/**'
+      - 'native/**/*.cpp'
+      - 'native/**/*.h'
+      - 'native/CMakeLists.txt'
       - 'scripts/build-native.mjs'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'vite.config.js'
-      - 'tailwind.config.js'
-      - 'postcss.config.js'
-      - 'index.html'
       - '.gitmodules'
       - '.github/workflows/main.yml'
   push:
     branches:
       - '**'
     paths:
-      - 'native/**'
-      - 'dsp/**'
-      - 'src/**'
-      - 'public/**'
+      - 'native/**/*.cpp'
+      - 'native/**/*.h'
+      - 'native/CMakeLists.txt'
       - 'scripts/build-native.mjs'
-      - 'package.json'
-      - 'pnpm-lock.yaml'
-      - 'vite.config.js'
-      - 'tailwind.config.js'
-      - 'postcss.config.js'
-      - 'index.html'
       - '.gitmodules'
       - '.github/workflows/main.yml'
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -4,48 +4,28 @@ on:
   workflow_dispatch:
   pull_request:
     paths:
-      - 'native/**'
       - 'dsp/**'
-      - 'src/**'
-      - 'public/**'
       - 'tests/**'
-      - 'scripts/build-native.mjs'
       - 'package.json'
       - 'pnpm-lock.yaml'
-      - 'vite.config.js'
       - 'vitest.integration.config.ts'
-      - 'tailwind.config.js'
-      - 'postcss.config.js'
-      - 'index.html'
-      - '.gitmodules'
       - '.github/workflows/test.yml'
   push:
     branches:
       - main
     paths:
-      - 'native/**'
       - 'dsp/**'
-      - 'src/**'
-      - 'public/**'
       - 'tests/**'
-      - 'scripts/build-native.mjs'
       - 'package.json'
       - 'pnpm-lock.yaml'
-      - 'vite.config.js'
       - 'vitest.integration.config.ts'
-      - 'tailwind.config.js'
-      - 'postcss.config.js'
-      - 'index.html'
-      - '.gitmodules'
       - '.github/workflows/test.yml'
 
 jobs:
   test:
-    runs-on: macos-latest
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-        with:
-          submodules: true
 
       - uses: pnpm/action-setup@v2
         with:
@@ -58,31 +38,6 @@ jobs:
 
       - name: Install dependencies
         run: pnpm install
-
-      - name: Build native plugin
-        shell: bash
-        run: pnpm run build
-
-      - name: Verify build artifacts
-        shell: bash
-        run: |
-          set -e
-
-          # Verify VST3 was built
-          if [ ! -d "native/build/scripted/SRVB_artefacts/Release/VST3/SRVB.vst3" ]; then
-            echo "❌ Error: VST3 artifact not found!"
-            exit 1
-          fi
-          echo "✅ VST3 artifact verified"
-
-          # Verify AU was built (macOS only)
-          if [ ! -d "native/build/scripted/SRVB_artefacts/Release/AU/SRVB.component" ]; then
-            echo "❌ Error: AU artifact not found!"
-            exit 1
-          fi
-          echo "✅ AU artifact verified"
-
-          echo "✅ All build artifacts verified successfully"
 
       - name: Run integration tests
         run: pnpm run test:integration


### PR DESCRIPTION
## Summary

- Build workflow only triggers on native C/C++ changes (*.cpp, *.h, CMakeLists.txt)
- Test workflow no longer builds native plugin - uses @elemaudio/offline-renderer instead
- Test workflow runs on ubuntu-latest instead of macos-latest (faster/cheaper)
- Removed unnecessary triggers for JS/TS/CSS files from build workflow

This significantly speeds up CI for JS-only changes by avoiding the slow native C++ compilation when it's not needed.

## Test plan

- [ ] Verify Test workflow runs and passes on ubuntu-latest
- [ ] Verify Build workflow only triggers when C++ files change
- [ ] Verify JS-only changes don't trigger Build workflow

Fixes #45

🤖 Generated with [Claude Code](https://claude.com/claude-code)