### PR TITLE
Add PR size guidelines to development workflow

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -220,6 +220,23 @@ gh pr create --title "Brief description" --body "Detailed description" --base ma
 - Reference to the issue: `Fixes #<number>`
 - Generated with Claude Code footer
 
+**PR Size Guidelines:**
+
+| Size | Lines Changed | Action |
+|------|---------------|--------|
+| Ideal | ~50 lines | Optimal |
+| Good | <200 lines | Proceed |
+| Acceptable | 200-400 lines | Consider splitting |
+| Too Large | 400+ lines | Must split |
+
+If a PR exceeds 400 lines:
+1. Stop working on the current PR
+2. Go back to the original issue and create sub-issues
+3. Split the work into smaller, independent PRs
+4. Each PR must add value on its own and not break anything
+
+**Note:** These are guidelines. Some changes (renaming a widely-used symbol, large refactors) legitimately touch many lines but are easy to review. Use judgment.
+
 ### 8. Monitor PR Status
 
 After creating or pushing to a PR, **monitor CI checks until all pass**:

--- a/docs/CODE_HYGIENE.md
+++ b/docs/CODE_HYGIENE.md
@@ -68,6 +68,35 @@ These checks run on every PR. **All checks block the PR from merging if they fai
 
 ---
 
+## PR Size Guidelines
+
+Keep PRs small for faster, more thorough reviews.
+
+| Size | Lines Changed | Action |
+|------|---------------|--------|
+| **Ideal** | ~50 lines | Optimal for review |
+| **Good** | <200 lines | Reviews complete in <1 hour |
+| **Acceptable** | 200-400 lines | Consider splitting |
+| **Too Large** | 400+ lines | Must split |
+
+### When a PR Gets Too Large
+
+1. **Stop** - Don't keep adding to an oversized PR
+2. **Create sub-issues** - Break the original issue into smaller pieces
+3. **Split the PR** - Create separate PRs for each sub-issue
+4. **Each PR must be self-contained** - Adds value, doesn't break anything
+
+### Why Size Matters
+
+- PRs under 200 lines merge ~40% faster
+- 50-line changes are 15% less likely to be reverted
+- Reviews of 200-400 lines yield 70-90% defect discovery
+- Beyond 400 lines, review quality drops significantly
+
+**Exceptions:** Some changes (renaming widely-used symbols, mechanical refactors) touch many lines but are easy to review. Use judgment.
+
+---
+
 ## Quick Reference
 
 | What | Command | When |


### PR DESCRIPTION
## Summary

Adds PR size guidelines based on industry research to help maintain code quality and review efficiency.

## Changes

**CLAUDE.md** - Added PR size table and splitting instructions to the "Create Pull Request" workflow section

**docs/CODE_HYGIENE.md** - Added new "PR Size Guidelines" section with:
- Size thresholds table
- Process for splitting oversized PRs
- Research-backed rationale for the thresholds

## Size Thresholds

| Size | Lines Changed | Action |
|------|---------------|--------|
| Ideal | ~50 lines | Optimal |
| Good | <200 lines | Proceed |
| Acceptable | 200-400 lines | Consider splitting |
| Too Large | 400+ lines | Must split |

## Why This Matters

Research shows:
- PRs under 200 lines merge ~40% faster
- 50-line changes are 15% less likely to be reverted
- Reviews of 200-400 lines yield 70-90% defect discovery
- Beyond 400 lines, review quality drops significantly

## Test plan

- [x] Guidelines are clear and actionable
- [x] Tables render correctly in markdown
- [x] This PR itself follows the guidelines (46 lines changed)

Fixes #88

🤖 Generated with [Claude Code](https://claude.com/claude-code)