### PR TITLE
Add LLM service types, schemas, and error class

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -18,6 +18,7 @@
     "react": "^18.2.0",
     "react-dom": "^18.2.0",
     "resize-observer-polyfill": "^1.5.1",
+    "zod": "^4.1.13",
     "zustand": "^4.3.8"
   },
   "devDependencies": {

--- a/packages/frontend/src/services/llm-service-error.ts
+++ b/packages/frontend/src/services/llm-service-error.ts
@@ -1,0 +1,15 @@
+import { LLMErrorCode } from './types.js';
+
+/**
+ * Custom error class for LLM service errors
+ */
+export class LLMServiceError extends Error {
+  constructor(
+    message: string,
+    public readonly code: LLMErrorCode,
+    public readonly cause?: unknown
+  ) {
+    super(message);
+    this.name = 'LLMServiceError';
+  }
+}

--- a/packages/frontend/src/services/schemas.ts
+++ b/packages/frontend/src/services/schemas.ts
@@ -1,0 +1,21 @@
+import { z } from 'zod';
+
+/**
+ * Schema for a DSP parameter that can be controlled in the UI
+ */
+export const parameterSchema = z.object({
+  name: z.string().describe('Parameter name in camelCase'),
+  min: z.number().describe('Minimum value'),
+  max: z.number().describe('Maximum value'),
+  default: z.number().describe('Default value'),
+  unit: z.string().optional().describe('Unit of measurement (e.g., "Hz", "dB", "ms")'),
+});
+
+/**
+ * Schema for generated DSP code response
+ */
+export const dspCodeSchema = z.object({
+  code: z.string().describe('Complete ElementaryJS DSP code'),
+  explanation: z.string().describe('What the code does'),
+  parameters: z.array(parameterSchema).describe('Controllable parameters'),
+});

--- a/packages/frontend/src/services/types.ts
+++ b/packages/frontend/src/services/types.ts
@@ -1,0 +1,30 @@
+import { z } from 'zod';
+import { parameterSchema, dspCodeSchema } from './schemas.js';
+
+export type Parameter = z.infer<typeof parameterSchema>;
+export type DSPCodeResponse = z.infer<typeof dspCodeSchema>;
+
+/**
+ * LLM service configuration
+ */
+export interface LLMServiceConfig {
+  apiKey: string;
+  model?: string;
+  maxTokens?: number;
+}
+
+/**
+ * Error codes for LLM service errors (const object for runtime access)
+ */
+export const LLMErrorCode = {
+  INVALID_API_KEY: 'INVALID_API_KEY',
+  RATE_LIMIT: 'RATE_LIMIT',
+  NETWORK_ERROR: 'NETWORK_ERROR',
+  UNKNOWN: 'UNKNOWN',
+} as const;
+
+/**
+ * Union type of all error code values
+ */
+// eslint-disable-next-line no-redeclare
+export type LLMErrorCode = (typeof LLMErrorCode)[keyof typeof LLMErrorCode];

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -112,6 +112,9 @@ importers:
       resize-observer-polyfill:
         specifier: ^1.5.1
         version: 1.5.1
+      zod:
+        specifier: ^4.1.13
+        version: 4.1.13
       zustand:
         specifier: ^4.3.8
         version: 4.5.7(@types/react@18.3.26)(react@18.3.1)
@@ -4575,6 +4578,10 @@ packages:
   /yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  /zod@4.1.13:
+    resolution: {integrity: sha512-AvvthqfqrAhNH9dnfmrfKzX5upOdjUVJYFqNSlkmGf64gRaTzlPwz99IHYnVs28qYAybvAlBV+H7pn0saFY4Ig==}
+    dev: false
 
   /zustand@4.5.7(@types/react@18.3.26)(react@18.3.1):
     resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}


### PR DESCRIPTION
## Summary
Foundation for the LLM service infrastructure - types, schemas, and error handling.

## Changes
- **schemas.ts**: Zod schemas for DSP code responses
  - `parameterSchema`: Schema for UI-controllable parameters (name, min, max, default, unit)
  - `dspCodeSchema`: Schema for generated DSP code (code, explanation, parameters)
- **types.ts**: TypeScript types derived from schemas
  - `Parameter`, `DSPCodeResponse` types inferred from schemas
  - `LLMServiceConfig` interface for service configuration
  - `LLMErrorCode` const object + type for error categorization
- **llm-service-error.ts**: Custom error class with error code support

## Dependencies
Adds `zod` dependency to frontend package for runtime schema validation.

## Test plan
- [ ] Types compile without errors
- [ ] No lint errors

Part of #29 (LLM Service Foundation)
Fixes #96

🤖 Generated with [Claude Code](https://claude.com/claude-code)