### PR TITLE
Add LLM service core implementation

### DIFF
--- a/packages/frontend/package.json
+++ b/packages/frontend/package.json
@@ -11,9 +11,11 @@
     "test:unit:coverage": "vitest run --config vitest.unit.config.ts --coverage"
   },
   "dependencies": {
+    "@ai-sdk/anthropic": "^2.0.50",
     "@elemaudio/core": "^4.0.1",
     "@heroicons/react": "^2.0.18",
     "@use-gesture/react": "^10.2.27",
+    "ai": "^5.0.104",
     "invariant": "^2.2.4",
     "react": "^18.2.0",
     "react-dom": "^18.2.0",

--- a/packages/frontend/src/services/index.ts
+++ b/packages/frontend/src/services/index.ts
@@ -1,0 +1,13 @@
+// Schemas
+export { parameterSchema, dspCodeSchema } from './schemas.js';
+
+// Types
+export type { Parameter, DSPCodeResponse, LLMServiceConfig } from './types.js';
+export { LLMErrorCode } from './types.js';
+
+// Error handling
+export { LLMServiceError } from './llm-service-error.js';
+export { mapApiError } from './map-api-error.js';
+
+// Service
+export { LLMService, createLLMService, isValidApiKeyFormat } from './llm-service.js';

--- a/packages/frontend/src/services/llm-service.ts
+++ b/packages/frontend/src/services/llm-service.ts
@@ -1,0 +1,161 @@
+import { createAnthropic } from '@ai-sdk/anthropic';
+import { generateObject, streamObject } from 'ai';
+import { readFileSync } from 'fs';
+import { fileURLToPath } from 'url';
+import { dirname, join } from 'path';
+import { z } from 'zod';
+
+import { dspCodeSchema } from './schemas.js';
+import { DSPCodeResponse, LLMServiceConfig, LLMErrorCode } from './types.js';
+import { LLMServiceError } from './llm-service-error.js';
+import { mapApiError } from './map-api-error.js';
+
+// Load system prompt from file
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = dirname(__filename);
+const SYSTEM_PROMPT = readFileSync(join(__dirname, 'system-prompt.txt'), 'utf-8');
+
+// ============================================================================
+// API Key Validation
+// ============================================================================
+
+/**
+ * Validates that an API key has the expected format for Anthropic
+ * @param apiKey - The API key to validate
+ * @returns true if valid format, false otherwise
+ */
+export function isValidApiKeyFormat(apiKey: string): boolean {
+  if (!apiKey || typeof apiKey !== 'string') {
+    return false;
+  }
+
+  // Anthropic API keys start with "sk-ant-" and have a specific length range
+  const trimmed = apiKey.trim();
+  if (!trimmed.startsWith('sk-ant-')) {
+    return false;
+  }
+
+  // Keys are typically 100+ characters
+  if (trimmed.length < 50) {
+    return false;
+  }
+
+  return true;
+}
+
+// ============================================================================
+// LLM Service Class
+// ============================================================================
+
+const DEFAULT_MODEL = 'claude-sonnet-4-20250514';
+const DEFAULT_MAX_TOKENS = 4096;
+
+/**
+ * Service for interacting with Claude API for DSP code generation
+ */
+export class LLMService {
+  private readonly anthropic;
+  private readonly model: string;
+  private readonly maxTokens: number;
+
+  constructor(config: LLMServiceConfig) {
+    if (!isValidApiKeyFormat(config.apiKey)) {
+      throw new LLMServiceError(
+        'Invalid API key format. Anthropic API keys should start with "sk-ant-".',
+        LLMErrorCode.INVALID_API_KEY
+      );
+    }
+
+    this.anthropic = createAnthropic({
+      apiKey: config.apiKey,
+    });
+    this.model = config.model ?? DEFAULT_MODEL;
+    this.maxTokens = config.maxTokens ?? DEFAULT_MAX_TOKENS;
+  }
+
+  /**
+   * Generate DSP code from a natural language prompt
+   * @param prompt - Description of the desired audio effect
+   * @returns Generated DSP code, explanation, and parameters
+   */
+  async generateDSPCode(prompt: string): Promise<DSPCodeResponse> {
+    try {
+      const result = await generateObject({
+        model: this.anthropic(this.model),
+        schema: dspCodeSchema,
+        system: SYSTEM_PROMPT,
+        prompt: `Generate ElementaryJS DSP code for the following audio effect:\n\n${prompt}`,
+        maxTokens: this.maxTokens,
+      });
+
+      return result.object;
+    } catch (error) {
+      throw mapApiError(error);
+    }
+  }
+
+  /**
+   * Generate DSP code with streaming support for real-time UI updates
+   * @param prompt - Description of the desired audio effect
+   * @param onPartialObject - Callback for partial object updates during streaming
+   * @returns Final generated DSP code response
+   */
+  async generateDSPCodeStream(
+    prompt: string,
+    onPartialObject?: (partial: Partial<DSPCodeResponse>) => void
+  ): Promise<DSPCodeResponse> {
+    try {
+      const result = streamObject({
+        model: this.anthropic(this.model),
+        schema: dspCodeSchema,
+        system: SYSTEM_PROMPT,
+        prompt: `Generate ElementaryJS DSP code for the following audio effect:\n\n${prompt}`,
+        maxTokens: this.maxTokens,
+      });
+
+      // Process partial objects if callback provided
+      if (onPartialObject) {
+        for await (const partialObject of result.partialObjectStream) {
+          onPartialObject(partialObject);
+        }
+      }
+
+      // Wait for final result
+      const finalResult = await result.object;
+      return finalResult;
+    } catch (error) {
+      throw mapApiError(error);
+    }
+  }
+
+  /**
+   * Validate that the API key works by making a minimal request
+   * @returns true if the API key is valid and working
+   */
+  async validateApiKey(): Promise<boolean> {
+    try {
+      // Make a minimal request to validate the key
+      await generateObject({
+        model: this.anthropic(this.model),
+        schema: z.object({ valid: z.boolean() }),
+        prompt: 'Respond with valid: true',
+        maxTokens: 50,
+      });
+      return true;
+    } catch (error) {
+      const mappedError = mapApiError(error);
+      if (mappedError.code === LLMErrorCode.INVALID_API_KEY) {
+        return false;
+      }
+      // Re-throw non-auth errors
+      throw mappedError;
+    }
+  }
+}
+
+/**
+ * Factory function to create an LLM service instance
+ */
+export function createLLMService(config: LLMServiceConfig): LLMService {
+  return new LLMService(config);
+}

--- a/packages/frontend/src/services/system-prompt.txt
+++ b/packages/frontend/src/services/system-prompt.txt
@@ -1,0 +1,10 @@
+You are an expert audio DSP engineer specializing in ElementaryJS, a functional reactive programming library for audio signal processing.
+
+When generating DSP code:
+1. Use ElementaryJS primitives (el.cycle, el.lowpass, el.highpass, el.delay, etc.)
+2. Ensure the code is complete and can be used directly
+3. Include proper signal flow from input to output
+4. Keep code efficient and avoid unnecessary computations
+5. Use meaningful parameter names in camelCase
+
+The code should export a function that takes input signals and returns processed output signals.

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -91,6 +91,9 @@ importers:
 
   packages/frontend:
     dependencies:
+      '@ai-sdk/anthropic':
+        specifier: ^2.0.50
+        version: 2.0.50(zod@4.1.13)
       '@elemaudio/core':
         specifier: ^4.0.1
         version: 4.0.1
@@ -100,6 +103,9 @@ importers:
       '@use-gesture/react':
         specifier: ^10.2.27
         version: 10.3.1(react@18.3.1)
+      ai:
+        specifier: ^5.0.104
+        version: 5.0.104(zod@4.1.13)
       invariant:
         specifier: ^2.2.4
         version: 2.2.4
@@ -157,6 +163,48 @@ importers:
         version: 4.0.14(@types/node@24.10.1)(jsdom@24.1.3)(tsx@4.20.6)
 
 packages:
+
+  /@ai-sdk/anthropic@2.0.50(zod@4.1.13):
+    resolution: {integrity: sha512-21PaHfoLmouOXXNINTsZJsMw+wE5oLR2He/1kq/sKokTVKyq7ObGT1LDk6ahwxaz/GoaNaGankMh+EgVcdv2Cw==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
+      zod: 4.1.13
+    dev: false
+
+  /@ai-sdk/gateway@2.0.17(zod@4.1.13):
+    resolution: {integrity: sha512-oVAG6q72KsjKlrYdLhWjRO7rcqAR8CjokAbYuyVZoCO4Uh2PH/VzZoxZav71w2ipwlXhHCNaInGYWNs889MMDA==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
+      '@vercel/oidc': 3.0.5
+      zod: 4.1.13
+    dev: false
+
+  /@ai-sdk/provider-utils@3.0.18(zod@4.1.13):
+    resolution: {integrity: sha512-ypv1xXMsgGcNKUP+hglKqtdDuMg68nWHucPPAhIENrbFAI+xCHiqPVN8Zllxyv1TNZwGWUghPxJXU+Mqps0YRQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/provider': 2.0.0
+      '@standard-schema/spec': 1.0.0
+      eventsource-parser: 3.0.6
+      zod: 4.1.13
+    dev: false
+
+  /@ai-sdk/provider@2.0.0:
+    resolution: {integrity: sha512-6o7Y2SeO9vFKB8lArHXehNuusnpddKPk7xqL7T2/b+OvXMRIXUO1rR4wcv1hAFUAT9avGZshty3Wlua/XA7TvA==}
+    engines: {node: '>=18'}
+    dependencies:
+      json-schema: 0.4.0
+    dev: false
 
   /@alloc/quick-lru@5.2.0:
     resolution: {integrity: sha512-UrcABB+4bUrFABwbluTIBErXwvbsU/V7TZWfmbgJfbkwiBuziS9gxdODUyuiecfdGQ85jglMW6juS3+z5TsKLw==}
@@ -1210,6 +1258,11 @@ packages:
       '@nodelib/fs.scandir': 2.1.5
       fastq: 1.19.1
 
+  /@opentelemetry/api@1.9.0:
+    resolution: {integrity: sha512-3giAOQvZiH5F9bMlMiv8+GSPMeqg0dbaeo58/0SlA9sxSqZhnUtxzX9/2FzyhS9sWQf5S0GJE0AKBrFqjpeYcg==}
+    engines: {node: '>=8.0.0'}
+    dev: false
+
   /@pkgjs/parseargs@0.11.0:
     resolution: {integrity: sha512-+1VkjdD0QBLPodGrJUeqarH8VAIvQODIbwh9XpP5Syisf7YoQgsJKPNFoqqLQlu+VQ/tVSshMR6loPMn8U+dPg==}
     engines: {node: '>=14'}
@@ -1398,7 +1451,6 @@ packages:
 
   /@standard-schema/spec@1.0.0:
     resolution: {integrity: sha512-m2bOd0f2RT9k8QJx1JN85cZYyH1RqFBdlwtkSlf4tBDYLCiiZnv1fIIwacK6cqwXavOydf0NPToMQgpKq+dVlA==}
-    dev: true
 
   /@types/babel__core@7.20.5:
     resolution: {integrity: sha512-qoQprZvz5wQFJwMDqeseRXWv3rqMvhgpbXFfVyWhbx9X47POIA6i/+dXefEmZKoAgOaTdaIgNSMqMIU61yRyzA==}
@@ -1654,6 +1706,11 @@ packages:
       react: 18.3.1
     dev: false
 
+  /@vercel/oidc@3.0.5:
+    resolution: {integrity: sha512-fnYhv671l+eTTp48gB4zEsTW/YtRgRPnkI2nT7x6qw5rkI1Lq2hTmQIpHPgyThI0znLK+vX2n9XxKdXZ7BUbbw==}
+    engines: {node: '>= 20'}
+    dev: false
+
   /@vitejs/plugin-react@4.7.0(vite@4.5.14):
     resolution: {integrity: sha512-gUu9hwfWvvEDBBmgtAowQCojwZmJ5mcLn3aufeCsitijs3+f2NsrPtlAWIR6OPiqljl96GVCUbLe0HyqIpVaoA==}
     engines: {node: ^14.18.0 || >=16.0.0}
@@ -1841,6 +1898,19 @@ packages:
     dependencies:
       clean-stack: 4.2.0
       indent-string: 5.0.0
+    dev: false
+
+  /ai@5.0.104(zod@4.1.13):
+    resolution: {integrity: sha512-MZOkL9++nY5PfkpWKBR3Rv+Oygxpb9S16ctv8h91GvrSif7UnNEdPMVZe3bUyMd2djxf0AtBk/csBixP0WwWZQ==}
+    engines: {node: '>=18'}
+    peerDependencies:
+      zod: ^3.25.76 || ^4.1.8
+    dependencies:
+      '@ai-sdk/gateway': 2.0.17(zod@4.1.13)
+      '@ai-sdk/provider': 2.0.0
+      '@ai-sdk/provider-utils': 3.0.18(zod@4.1.13)
+      '@opentelemetry/api': 1.9.0
+      zod: 4.1.13
     dev: false
 
   /ajv@6.12.6:
@@ -2564,6 +2634,11 @@ packages:
   /eventemitter3@5.0.1:
     resolution: {integrity: sha512-GWkBvjiSZK87ELrYOSESUYeVIc9mvLLf/nXalMOS5dYrgZq9o5OVkbZAVM06CVxYsCwH9BDZFPlQTlPA1j4ahA==}
 
+  /eventsource-parser@3.0.6:
+    resolution: {integrity: sha512-Vo1ab+QXPzZ4tCa8SwIHJFaSzy4R6SHf7BY79rFBDf0idraZWAkYrDjDj8uWaSm3S2TK+hJ7/t1CEmZ7jXw+pg==}
+    engines: {node: '>=18.0.0'}
+    dev: false
+
   /expect-type@1.2.2:
     resolution: {integrity: sha512-JhFGDVJ7tmDJItKhYgJCGLOWjuK9vPxiXoUFLwLDc99NlmklilbiQJwoctZtt13+xMw91MCk/REan6MWHqDjyA==}
     engines: {node: '>=12.0.0'}
@@ -3061,6 +3136,10 @@ packages:
   /json-schema-traverse@0.4.1:
     resolution: {integrity: sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg==}
     dev: true
+
+  /json-schema@0.4.0:
+    resolution: {integrity: sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==}
+    dev: false
 
   /json-stable-stringify-without-jsonify@1.0.1:
     resolution: {integrity: sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==}


### PR DESCRIPTION
## Summary
Core LLM service for generating ElementaryJS DSP code from natural language prompts using Vercel AI SDK with Anthropic provider.

## Changes
- **llm-service.ts**: Main LLMService class
  - `generateDSPCode()`: Generate DSP code with structured Zod output
  - `generateDSPCodeStream()`: Streaming generation with partial object updates
  - `validateApiKey()`: Validate API key with minimal request
  - `isValidApiKeyFormat()`: Format validation (sk-ant-* prefix)
- **system-prompt.txt**: ElementaryJS-specific system prompt
- **index.ts**: Public exports for the services module

## New Dependencies
- `ai` (Vercel AI SDK) for structured generation
- `@ai-sdk/anthropic` for Claude model support

## Dependencies
- Depends on #102 (PR for #97 - API error mapping)

## Test plan
- [ ] TypeScript compiles without errors
- [ ] No lint errors
- [ ] Unit tests (in follow-up PR #99)

Part of #29 (LLM Service Foundation)
Fixes #98

🤖 Generated with [Claude Code](https://claude.com/claude-code)